### PR TITLE
Fix UI build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@ dist/
 downloads/
 eggs/
 .eggs/
-lib/
+# lib/
 lib64/
 parts/
 sdist/

--- a/ui/src/components/pages/PageKnowledgeBase.tsx
+++ b/ui/src/components/pages/PageKnowledgeBase.tsx
@@ -53,7 +53,7 @@ export function PageKnowledgeBase({ id }: PageKnowledgeBaseProps) {
           <div className="grid grid-cols-2 gap-4">
             <div>
               <Typography variant="h4">Ingest Method:</Typography>
-              <Typography variant="p">{data.ingestion_method}</Typography>
+              <Typography variant="p">{data.ingest_method}</Typography>
             </div>
             <div>
               <Typography variant="h4">Splitter:</Typography>

--- a/ui/src/index.ts
+++ b/ui/src/index.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
-import { pipelineConfigSchema } from "./services/chatbot";
+import { clientPipelineConfigSchema } from "./services/chatbot-service";
 
-type PipelineConfig = z.infer<typeof pipelineConfigSchema>;
+type PipelineConfig = z.infer<typeof clientPipelineConfigSchema>;
 
 export type { PipelineConfig };

--- a/ui/src/lib/utils.ts
+++ b/ui/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { type ClassValue, clsx } from "clsx"
+import { twMerge } from "tailwind-merge"
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs))
+}

--- a/ui/src/services/query-service.ts
+++ b/ui/src/services/query-service.ts
@@ -1,5 +1,4 @@
 import axios from "axios";
-import { z } from "zod";
 
 async function sendMessage(id: string, message: string) {
   const response = await axios.post(`/api/query`, { message, chatbotId: id });


### PR DESCRIPTION
- parent `.gitignore`file had `/lib`, which prevented the nested `/ui/src/lib` folder from getting onto the repo, preventing the vite react build
- also fixed minor TS errors from module import typos